### PR TITLE
fix: do not add empty targets

### DIFF
--- a/sample/messages.no-target.fr.xlf
+++ b/sample/messages.no-target.fr.xlf
@@ -4,7 +4,6 @@
     <body>
       <trans-unit id="af2ccf4b5dba59616e92cf1531505af02da8f6d2" datatype="html">
         <source>Hello i18n!</source>
-        <target/>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
       </trans-unit>
@@ -20,15 +19,13 @@
         <note priority="1" from="description">A goodbye message for the localized component</note>
         <note priority="1" from="meaning">localized.component.goodbye</note>
       </trans-unit>
-      <trans-unit id="b0459823058205380235820538108f51652e016a" datatype="html">
-        <source>One</source>
-        <target/>
-        <note priority="1" from="description">A message with non-alpha characters</note>
-        <note priority="1" from="meaning">localized.component.1</note>
+      <trans-unit id="ba95e06a57c2a716c89e1a9b4fa30f51652e016a" datatype="html">
+        <source>Not translated.</source>
+        <note priority="1" from="description">A message with missing translation for the localized component</note>
+        <note priority="1" from="meaning">localized.component.not_translated</note>
       </trans-unit>
       <trans-unit id="225c24c98a62f1f8974e1c1206f6eac06d7e5b62" datatype="html">
         <source>Créé par <x id="INTERPOLATION"/> le <x id="INTERPOLATION_1"/></source>
-        <target/>
         <note priority="1" from="description">Info création par qui / quand</note>
       </trans-unit>
     </body>

--- a/sample/messages.no-target.xlf
+++ b/sample/messages.no-target.xlf
@@ -17,6 +17,11 @@
         <note priority="1" from="description">A goodbye message for the localized component</note>
         <note priority="1" from="meaning">localized.component.goodbye</note>
       </trans-unit>
+      <trans-unit id="ba95e06a57c2a716c89e1a9b4fa30f51652e016a" datatype="html">
+        <source>Not translated.</source>
+        <note priority="1" from="description">A message with missing translation for the localized component</note>
+        <note priority="1" from="meaning">localized.component.not_translated</note>
+      </trans-unit>
       <trans-unit id="225c24c98a62f1f8974e1c1206f6eac06d7e5b62" datatype="html">
         <source>Créé par <x id="INTERPOLATION"/> le <x id="INTERPOLATION_1"/></source>
         <note priority="1" from="description">Info création par qui / quand</note>

--- a/spec/translate.spec.js
+++ b/spec/translate.spec.js
@@ -81,6 +81,18 @@ describe('translate', function() {
             expect(target(1)).toBe(lang.localized.component.hello);
             expect(target(2)).toBe(lang.localized.component.goodbye);
         });
+
+        it("does not add targets to non-tagged units", function() {
+            translate(messages, lang);
+
+            expect(units.eq(0).find('target').length).toBe(0);
+        });
+
+        it("does not add targets to tagged units without translations", function() {
+            translate(messages, lang);
+
+            expect(units.eq(3).find('target').length).toBe(0);
+        });
     });
 
 });

--- a/spec/translate.spec.js
+++ b/spec/translate.spec.js
@@ -82,13 +82,13 @@ describe('translate', function() {
             expect(target(2)).toBe(lang.localized.component.goodbye);
         });
 
-        it("does not add targets to non-tagged units", function() {
+        it('does not add targets to non-tagged units', function() {
             translate(messages, lang);
 
             expect(units.eq(0).find('target').length).toBe(0);
         });
 
-        it("does not add targets to tagged units without translations", function() {
+        it('does not add targets to tagged units without translations', function() {
             translate(messages, lang);
 
             expect(units.eq(3).find('target').length).toBe(0);

--- a/src/translate.js
+++ b/src/translate.js
@@ -40,7 +40,7 @@ const translate = (doc, lang, force) => {
             };
         })
         .filter(({ found }) => found)
-        .map(({ id, unit, text }) => {
+        .map(({ unit, text }) => {
             const source = unit.find('source');
             let target = unit.find('target');
             if (target.length === 0 && source.length === 1) {


### PR DESCRIPTION
Empty targets should not be added in case the message is not translated.